### PR TITLE
Allow collapsing details of online hosts

### DIFF
--- a/nmap-bootstrap.xsl
+++ b/nmap-bootstrap.xsl
@@ -36,6 +36,9 @@ Andreas Hontzia (@honze_net)
             height: 180px;
             background-color: #f5f5f5;
           }
+          .clickable {
+            cursor: pointer;
+          }
         </style>
         <title>Scan Report Nmap <xsl:value-of select="/nmaprun/@version"/></title>
       </head>
@@ -126,14 +129,17 @@ Andreas Hontzia (@honze_net)
           <script>
             $(document).ready(function() {
               $('#table-overview').DataTable();
+              $('h3.panel-title').click(function() {
+                $(this).find("i.glyphicon").toggleClass("glyphicon-chevron-down glyphicon-chevron-right");
+              });
             });
           </script>
           <h2 id="onlinehosts" class="target">Online Hosts</h2>
           <xsl:for-each select="/nmaprun/host[status/@state='up']">
             <div class="panel panel-default">
-              <div class="panel-heading" data-toggle="collapse">
-                  <xsl:attribute name="href">#<xsl:value-of select="translate(address/@addr, '.', '-')"/></xsl:attribute>
-                <h3 class="panel-title"><xsl:value-of select="address/@addr"/><xsl:if test="count(hostnames/hostname) > 0"> - <xsl:value-of select="hostnames/hostname/@name"/></xsl:if></h3>
+              <div class="panel-heading clickable" data-toggle="collapse">
+                  <xsl:attribute name="data-target">#<xsl:value-of select="translate(address/@addr, '.', '-')"/></xsl:attribute>
+                <h3 class="panel-title"><i class="glyphicon glyphicon glyphicon-chevron-right"></i><xsl:value-of select="address/@addr"/><xsl:if test="count(hostnames/hostname) > 0"> - <xsl:value-of select="hostnames/hostname/@name"/></xsl:if></h3>
               </div>
               <div class="panel-body collapse in">
                 <xsl:attribute name="id"><xsl:value-of select="translate(address/@addr, '.', '-')"/></xsl:attribute>

--- a/nmap-bootstrap.xsl
+++ b/nmap-bootstrap.xsl
@@ -131,10 +131,12 @@ Andreas Hontzia (@honze_net)
           <h2 id="onlinehosts" class="target">Online Hosts</h2>
           <xsl:for-each select="/nmaprun/host[status/@state='up']">
             <div class="panel panel-default">
-              <div class="panel-heading">
+              <div class="panel-heading" data-toggle="collapse">
+                  <xsl:attribute name="href">#<xsl:value-of select="translate(address/@addr, '.', '-')"/></xsl:attribute>
                 <h3 class="panel-title"><xsl:value-of select="address/@addr"/><xsl:if test="count(hostnames/hostname) > 0"> - <xsl:value-of select="hostnames/hostname/@name"/></xsl:if></h3>
               </div>
-              <div class="panel-body">
+              <div class="panel-body collapse in">
+                <xsl:attribute name="id"><xsl:value-of select="translate(address/@addr, '.', '-')"/></xsl:attribute>
                 <xsl:if test="count(hostnames/hostname) > 0">
                   <h4>Hostnames</h4>
                   <ul>


### PR DESCRIPTION
I've expanded the template a bit by adding support for collapsing the details of online hosts upon clicking the header bar.